### PR TITLE
Add unit tests to improve branch coverage of core/domain/skill_services.py

### DIFF
--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -274,6 +274,25 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
             }
         )
 
+    def test_get_descriptions_of_skills_skips_nonevalue_skills(self) -> None:
+        skill_1 = self.save_new_skill(
+            'skill_id_1', self.user_id_admin, description='Description 1',
+            misconceptions=[],
+            skill_contents=None
+        )
+        with self.swap(skill_services, 'get_multi_skill_summaries', lambda skill_ids=False: [None, skill_1]):
+            skill_descriptions, _ = skill_services.get_descriptions_of_skills(['skill_id_1'])
+            self.assertEqual(
+                skill_descriptions, {
+                    'skill_id_1': 'Description 1'
+                }
+            )
+        with self.swap(skill_services, 'get_multi_skill_summaries', lambda skill_ids=False: [None]):
+            skill_descriptions, _ = skill_services.get_descriptions_of_skills(['skill_id_1'])
+            self.assertEqual(
+                skill_descriptions, {}
+            )
+
     def test_get_rubrics_of_linked_skills(self) -> None:
         example_1 = skill_domain.WorkedExample(
             state_domain.SubtitledHtml('2', '<p>Example Question 1</p>'),

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -346,6 +346,44 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
             }
         )
 
+    def test_get_rubrics_skips_nonevalue_skills(self) -> None:
+        skill_1 = self.save_new_skill(
+            'skill_id_1', self.user_id_admin, description='Description 1',
+            misconceptions=[],
+            skill_contents=None,
+            rubrics=[
+                skill_domain.Rubric(
+                    constants.SKILL_DIFFICULTIES[0], ['Explanation 1']),
+                skill_domain.Rubric(
+                    constants.SKILL_DIFFICULTIES[1], ['Explanation 2']),
+                skill_domain.Rubric(
+                    constants.SKILL_DIFFICULTIES[2], ['Explanation 3']),
+            ]
+        )
+        with self.swap(skill_fetchers, 'get_multi_skills', lambda skill_ids, strict=False: [None, skill_1]):
+            skill_rubrics, _ = skill_services.get_rubrics_of_skills(['skill_id_1'])
+            self.assertEqual(
+                skill_rubrics, {
+                    'skill_id_1': [
+                        skill_domain.Rubric(
+                            constants.SKILL_DIFFICULTIES[0], ['Explanation 1']
+                        ).to_dict(),
+                        skill_domain.Rubric(
+                            constants.SKILL_DIFFICULTIES[1], ['Explanation 2']
+                        ).to_dict(),
+                        skill_domain.Rubric(
+                            constants.SKILL_DIFFICULTIES[2], ['Explanation 3']
+                        ).to_dict()]
+                }
+            )
+        with self.swap(skill_fetchers, 'get_multi_skills', lambda skill_ids, strict=False: [None]):
+            skill_rubrics, _ = skill_services.get_rubrics_of_skills(['skill_id_1'])
+            self.assertEqual(
+                skill_rubrics, {
+                    'skill_id_1': None
+                }
+            ) 
+
     def test_get_skill_from_model(self) -> None:
         skill_model = skill_models.SkillModel.get(self.SKILL_ID)
         skill = skill_fetchers.get_skill_from_model(skill_model)

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -435,6 +435,36 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(augmented_skill_summaries[0].id, self.SKILL_ID)
         self.assertEqual(augmented_skill_summaries[1].id, self.SKILL_ID2)
 
+    def test_filter_skills_by_status_unassigned_with_assigned_skills(self) -> None:
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description2',
+            prerequisite_skill_ids=['skill_id_1', 'skill_id_2'])
+
+        topic_id = topic_fetchers.get_new_topic_id()
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='topic1',
+            abbreviated_name='topic-one', url_fragment='topic-one',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID], # skill id (1) already saved
+            subtopics=[], next_subtopic_id=1)
+
+        self.save_new_valid_classroom(
+            topic_id_to_prerequisite_topic_ids={
+                topic_id: []
+            }
+        )
+
+        augmented_skill_summaries, next_cursor, more = (
+            skill_services.get_filtered_skill_summaries(
+                self.num_queries_to_fetch, 'Unassigned', None, [],
+                None, None))
+        self.assertEqual(len(augmented_skill_summaries), 1)
+        self.assertEqual(augmented_skill_summaries[0].id, self.SKILL_ID2)
+        self.assertEqual(next_cursor, None)
+        self.assertFalse(more)
+        
     def test_cursor_behaves_correctly_when_fetching_skills_in_batches(
         self
     ) -> None:

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -125,6 +125,29 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
         with self.assertRaisesRegex(Exception, 'Invalid change dict.'):
             skill_services.apply_change_list(
                 self.SKILL_ID, invalid_skill_change_list, self.user_id_a)  # type: ignore[arg-type]
+    
+    def test_apply_change_list_with_invalid_cmd_name_ignores_invalid_cmd_name(self) -> None:
+        class MockSkillChange:
+            def __init__(self, cmd: str, property_name: str) -> None:
+                self.cmd = cmd
+                self.property_name = property_name
+        
+        invalid_skill_change_list = [MockSkillChange(
+            'invalid_cmd', 'description')]
+        
+
+        with self.swap(skill_domain.SkillChange, "ALLOWED_COMMANDS", [
+            {
+                'name': "invalid_cmd",
+                'required_attribute_names': [],
+                'optional_attribute_names': [],
+                'user_id_attribute_names': [],
+                'allowed_values': {},
+                'deprecated_values': {}
+            }
+        ]):
+            skill_services.apply_change_list(
+                self.SKILL_ID, invalid_skill_change_list, self.user_id_a)
 
     def test_compute_summary(self) -> None:
         skill = skill_fetchers.get_skill_by_id(self.SKILL_ID)


### PR DESCRIPTION
Added test functions in **core/domain/skill_services_tests.py** .These tests ensure proper handling of edge cases and expected behaviors in scenarios involving skill filtering, rubric retrieval, and description retrieval. The aim is to increase branch coverage by handling lines that aren't covered through targeted tests. All added tests were run locally and passed successfully and thus increase coverage.

Changes Made:
Test for Ignoring Invalid Commands in Skill Change List:
**Function Name:** test_apply_change_list_with_invalid_cmd_name_ignores_invalid_cmd_name
Verifies that apply_change_list properly skips invalid commands in a skill change list.
Includes a mock class MockSkillChange and temporarily modifies ALLOWED_COMMANDS to validate behavior.

Test for Filtering Unassigned Skills:
**Function Name:** test_filter_skills_by_status_unassigned_with_assigned_skills
Confirms that get_filtered_skill_summaries accurately filters unassigned skills, even when other skills are already assigned to topics.
Validates correct handling of results, including cursors and the more value.

Test for Skipping None-Value Skills in Rubric Retrieval:
**Function Name:** test_get_rubrics_skips_nonevalue_skills
Ensures get_rubrics_of_skills skips over skills with None values when fetching rubrics.
Covers cases where some or all skills in the input list are None.

Test for Skipping None-Value Skills in Description Retrieval:
**Function Name:** test_get_description_of_skills_skips_nonevalue_skills
Verifies that get_descriptions_of_skills skips skills with None values when fetching descriptions.
Confirms accurate behavior in both mixed and fully None scenarios.

