### PR TITLE
Unit tests to improve Coverage of [core/domain/skill_services.py]

### DIFF
--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -1816,3 +1816,117 @@ class SkillMigrationTests(test_utils.GenericTestBase):
         self.assertEqual(
             skill.rubrics[2].explanations,
             ['Hard explanation', html_content])
+
+    def test_remove_skill_from_all_topics_skips_subtopics_without_skill_id(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description2',
+            misconceptions=[],
+            skill_contents=None
+        )
+
+        subtopic = topic_domain.Subtopic.from_dict({
+            'id': 1,
+            'title': 'subtopic1',
+            'skill_ids': [self.SKILL_ID],
+            'thumbnail_filename': None,
+            'thumbnail_bg_color': None,
+            'thumbnail_size_in_bytes': None,
+            'url_fragment': 'subtopic-one'
+        })
+
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-three', url_fragment='topic-three',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID2],
+            subtopics=[subtopic], next_subtopic_id=2)
+        
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID2))
+        self.assertEqual(len(topic_assignments_dict), 1)
+        skill_services.remove_skill_from_all_topics(self.USER_ID, self.SKILL_ID2)
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID2))
+        self.assertEqual(len(topic_assignments_dict), 0)
+
+        topic = topic_fetchers.get_topic_by_id(topic_id)
+        self.assertEqual(topic.subtopics[0].skill_ids, [self.SKILL_ID])
+
+    def test_apply_change_list_with_invalid_skill_property_name_ignores_cmd(self) -> None:
+        class MockSkillChange:
+            def __init__(self, cmd: str, property_name: str) -> None:
+                self.cmd = cmd
+                self.property_name = property_name
+        
+        invalid_skill_change_list = [MockSkillChange(
+            skill_domain.CMD_UPDATE_SKILL_PROPERTY, 'invalid_skill_property_name')]
+
+        with self.swap(skill_domain.SkillChange, "SKILL_PROPERTIES", ["invalid_skill_property_name"]):
+            skill_services.apply_change_list(
+                self.SKILL_ID, invalid_skill_change_list, self.user_id_a)
+            
+    def test_update_skill_with_delete_skill_misconception_and_other_commands(self) -> None:
+        skill = skill_fetchers.get_skill_by_id(self.SKILL_ID)
+
+        self.assertEqual(len(skill.misconceptions), 1)
+        self.assertEqual(skill.misconceptions[0].id, self.MISCONCEPTION_ID_1)
+
+        changelist = [
+            skill_domain.SkillChange({
+                'cmd': skill_domain.CMD_DELETE_SKILL_MISCONCEPTION,
+                'misconception_id': self.MISCONCEPTION_ID_1,
+            }),
+            skill_domain.SkillChange({
+                'cmd': skill_domain.CMD_UPDATE_SKILL_PROPERTY,
+                'property_name': skill_domain.SKILL_PROPERTY_LANGUAGE_CODE,
+                'old_value': 'en',
+                'new_value': 'bn'
+            })
+        ]
+
+        skill_services.update_skill(
+            self.USER_ID, self.SKILL_ID, changelist, 'Change language code.')
+        
+        skill = skill_fetchers.get_skill_by_id(self.SKILL_ID)
+        self.assertEqual(len(skill.misconceptions), 0)
+        self.assertEqual(skill.language_code, 'bn')
+
+    def test_get_untriaged_skill_summaries_with_merged_skills_and_assigned_topics(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description 2')
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-three', url_fragment='topic-three',
+            description='Description1', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID],
+            subtopics=[], next_subtopic_id=1)
+        # merge skillid
+        change_list = [
+            skill_domain.SkillChange({
+                'cmd': skill_domain.CMD_UPDATE_SKILL_PROPERTY,
+                'property_name': (skill_domain.SKILL_PROPERTY_SUPERSEDING_SKILL_ID),
+                'old_value': '',
+                'new_value': 'TestSkillId'
+            })
+        ]
+        skill_services.update_skill(
+            self.USER_ID, self.SKILL_ID, change_list, 'Merging skill.')
+        
+        skill_summaries = skill_services.get_all_skill_summaries()
+        skill_ids_assigned_to_some_topic = (
+            topic_fetchers.get_all_skill_ids_assigned_to_some_topic())
+        merged_skill_ids = skill_services.get_merged_skill_ids()
+
+        untriaged_skill_summaries = (
+            skill_services.get_untriaged_skill_summaries(
+                skill_summaries, skill_ids_assigned_to_some_topic,
+                merged_skill_ids))
+        
+        self.assertEqual(len(untriaged_skill_summaries), 1)
+        self.assertEqual(untriaged_skill_summaries[0].id, self.SKILL_ID2)


### PR DESCRIPTION
Added tests in file [core/domain/skill_services_tests.py] to handle edge cases as well as improve branch coverage. Tests were run locally, passed successfully.

**Changes Made:**
**1. Skip Subtopics without skill IDs**
Function: test_remove_skill_from_all_topics_skips_subtopics_without_skill_id
Ensures proper behavior, when removing skill that is NOT linked to certain subtopics.

**2. Ignore invalid commands**
Function: test_apply_change_list_with_invalid_skill_property_name_ignores_cmd
Function verifies that invalid property names in a change list are ignored safely.

**3. Simultaneous skill updates**
Function: test_update_skill_with_delete_skill_misconception_and_other_commands
Tests applying multiple changes, like deleting misconceptions and updating properties.

**4. Filter untriaged skills**
Function: test_get_untriaged_skill_summaries_with_merged_skills_and_assigned_topics
It confirms accurate filtering of untriaged skills (even with merges and assignments).

_These additions enhance reliability, improve coverage, and ensure correct behavior for key functionalities._