### PR TITLE
Add branch coverage in the core/domain/skill_services_tests.py 

### DIFF
--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -777,6 +777,43 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
             skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
         self.assertEqual(len(topic_assignments_dict), 1)
 
+def test_replace_skill_id_in_all_topics_skips_subtopics_without_skill_id(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description2',
+            misconceptions=[],
+            skill_contents=None
+        )
+        subtopic_1 = topic_domain.Subtopic.from_dict({
+            'id': 1,
+            'title': 'subtopic2',
+            'skill_ids': [self.SKILL_ID],
+            'thumbnail_filename': None,
+            'thumbnail_bg_color': None,
+            'thumbnail_size_in_bytes': None,
+            'url_fragment': 'subtopic-one'
+        })
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-three', url_fragment='topic-three',
+            description='Description1', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID2],
+            subtopics=[subtopic_1], next_subtopic_id=2)
+        
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
+        self.assertEqual(len(topic_assignments_dict), 0)
+        skill_services.replace_skill_id_in_all_topics(
+            self.USER_ID, self.SKILL_ID2, 'new_skill_id')
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
+        self.assertEqual(len(topic_assignments_dict), 1)
+
+        topic = topic_fetchers.get_topic_by_id(topic_id)
+        self.assertNotEqual(topic.subtopics[0].skill_ids, ['new_skill_id_2'])
+        self.assertEqual(topic.subtopics[0].skill_ids, [self.SKILL_ID])
+    
     def test_remove_skill_from_all_topics(self) -> None:
         topic_id = topic_fetchers.get_new_topic_id()
         topic_id_1 = topic_fetchers.get_new_topic_id()

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -737,6 +737,46 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(topic_assignments[1].topic_version, 1)
         self.assertEqual(topic_assignments[1].subtopic_id, 1)
 
+     def test_replace_skill_id_in_all_topics_skips_topics_without_skill_id(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        topic_id_1 = topic_fetchers.get_new_topic_id()
+
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description2',
+            misconceptions=[],
+            skill_contents=None
+        )
+
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-five', url_fragment='topic-five',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID],
+            subtopics=[], next_subtopic_id=1)
+        self.save_new_topic(
+            topic_id_1, self.USER_ID, name='Topic2',
+            abbreviated_name='topic-six', url_fragment='topic-six',
+            description='Description2', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID2],
+            subtopics=[], next_subtopic_id=2)
+
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
+        self.assertEqual(len(topic_assignments_dict), 0)
+        skill_services.replace_skill_id_in_all_topics(
+            self.USER_ID, 'nonexistent_skill_id', 'new_skill_id')
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
+        self.assertEqual(len(topic_assignments_dict), 0)
+        skill_services.replace_skill_id_in_all_topics(
+            self.USER_ID, self.SKILL_ID, 'new_skill_id')
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill('new_skill_id'))
+        self.assertEqual(len(topic_assignments_dict), 1)
+
     def test_remove_skill_from_all_topics(self) -> None:
         topic_id = topic_fetchers.get_new_topic_id()
         topic_id_1 = topic_fetchers.get_new_topic_id()

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -545,6 +545,74 @@ class SkillServicesUnitTests(test_utils.GenericTestBase):
         self.assertEqual(next_cursor, None)
         self.assertFalse(more)
 
+    def test_get_all_topic_assignments_for_skill(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        topic_id_1 = topic_fetchers.get_new_topic_id()
+        topic_id_2 = topic_fetchers.get_new_topic_id()
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-three', url_fragment='topic-three',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID],
+            subtopics=[], next_subtopic_id=1)
+
+        subtopic = topic_domain.Subtopic.from_dict({
+            'id': 1,
+            'title': 'subtopic1',
+            'skill_ids': [self.SKILL_ID],
+            'thumbnail_filename': None,
+            'thumbnail_bg_color': None,
+            'thumbnail_size_in_bytes': None,
+            'url_fragment': 'subtopic-one'
+        })
+        self.save_new_topic(
+            topic_id_1, self.USER_ID, name='Topic2',
+            abbreviated_name='topic-four', url_fragment='topic-four',
+            description='Description2', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[],
+            subtopics=[subtopic], next_subtopic_id=2)    
+        
+        # with skill assigned to topic but not subtopic
+        subtopic_1 = topic_domain.Subtopic.from_dict({
+            'id': 2,
+            'title': 'subtopic2',
+            'skill_ids': [],
+            'thumbnail_filename': None,
+            'thumbnail_bg_color': None,
+            'thumbnail_size_in_bytes': None,
+            'url_fragment': 'subtopic-two'
+        })
+        self.save_new_topic(
+            topic_id_2, self.USER_ID, name='Topic3',
+            abbreviated_name='topic-five', url_fragment='topic-five',
+            description='Description3', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID],
+            subtopics=[subtopic_1], next_subtopic_id=3)
+        
+        topic_assignments = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID))
+        topic_assignments = sorted(
+            topic_assignments, key=lambda i: i.topic_name)
+        self.assertEqual(len(topic_assignments), 3)
+        self.assertEqual(topic_assignments[0].topic_name, 'Topic1')
+        self.assertEqual(topic_assignments[0].topic_id, topic_id)
+        self.assertEqual(topic_assignments[0].topic_version, 1)
+        self.assertIsNone(topic_assignments[0].subtopic_id)
+
+        self.assertEqual(topic_assignments[1].topic_name, 'Topic2')
+        self.assertEqual(topic_assignments[1].topic_id, topic_id_1)
+        self.assertEqual(topic_assignments[1].topic_version, 1)
+        self.assertEqual(topic_assignments[1].subtopic_id, 1)
+
+        self.assertEqual(topic_assignments[2].topic_name, 'Topic3')
+        self.assertEqual(topic_assignments[2].topic_id, topic_id_2)
+        self.assertEqual(topic_assignments[2].topic_version, 1)
+        self.assertIsNone(topic_assignments[2].subtopic_id)
+        
     def test_filter_skills_by_keywords(self) -> None:
         self.save_new_skill(
             self.SKILL_ID2, self.USER_ID, description='Alpha',

--- a/core/domain/skill_services_test.py
+++ b/core/domain/skill_services_test.py
@@ -848,6 +848,43 @@ def test_replace_skill_id_in_all_topics_skips_subtopics_without_skill_id(self) -
             skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID))
         self.assertEqual(len(topic_assignments_dict), 0)
 
+def test_remove_skill_from_all_topics_skips_topics_without_skill_id(self) -> None:
+        topic_id = topic_fetchers.get_new_topic_id()
+        topic_id_1 = topic_fetchers.get_new_topic_id()
+        
+        self.save_new_skill(
+            self.SKILL_ID2, self.USER_ID, description='Description2',
+            misconceptions=[],
+            skill_contents=None
+        )
+
+        self.save_new_topic(
+            topic_id, self.USER_ID, name='Topic1',
+            abbreviated_name='topic-five', url_fragment='topic-five',
+            description='Description',
+            canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID],
+            subtopics=[], next_subtopic_id=1)
+        self.save_new_topic(
+            topic_id_1, self.USER_ID, name='Topic2',
+            abbreviated_name='topic-six', url_fragment='topic-six',
+            description='Description2', canonical_story_ids=[],
+            additional_story_ids=[],
+            uncategorized_skill_ids=[self.SKILL_ID2],
+            subtopics=[], next_subtopic_id=2)
+
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID))
+        self.assertEqual(len(topic_assignments_dict), 1)
+        skill_services.remove_skill_from_all_topics(self.USER_ID, self.SKILL_ID)
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID))
+        self.assertEqual(len(topic_assignments_dict), 0)
+        topic_assignments_dict = (
+            skill_services.get_all_topic_assignments_for_skill(self.SKILL_ID2))
+        self.assertEqual(len(topic_assignments_dict), 1)
+
     def test_successfully_replace_skill_id_in_all_topics(self) -> None:
         topic_id = topic_fetchers.get_new_topic_id()
         topic_id_1 = topic_fetchers.get_new_topic_id()


### PR DESCRIPTION
Unit tests were added to the skill_services_tests.py to improve branch coverage of core/domain/skill_services.py. These tests focus on verifying that skill assignments and modifications are handled correctly across various topics and subtopics.

Created 4 functions that helped us achieve this:

**test_get_all_topic_assignments_for_skill**: ensures skills are properly retrieved from topics and subtopics.

**test_replace_skill_id_in_all_topics_skips_topics_without_skill_id:** confirms that skill ID replacements are restricted to topics where the ID originally exists, preventing unwanted changes.

**test_replace_skill_id_in_all_topics_skips_subtopics_without_skill_id:** makes sure that subtopics not containing the targeted skill ID remain untouched.

**test_remove_skill_from_all_topics_skips_topics_without_skill_id:** checks that skill removals are accurately executed only in topics that contain the skill.